### PR TITLE
Add texlive-fonts-extra to be able to use fontawesome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y texlive texlive-binaries etoolbox texinfo lmodern wget
+RUN apt-get update && apt-get install -y texlive texlive-binaries etoolbox texinfo lmodern wget texlive-fonts-extra
 
 RUN wget http://mirrors.ctan.org/macros/latex/contrib/moderncv.zip && \
   unzip moderncv.zip && \


### PR DESCRIPTION
To be able to use fontawesome in moderncv we need to install texlive-fonts-extra.

I hope this PR is OK for you, if not, let me know it.
